### PR TITLE
fix: Remove unnecessary default_app_config definitions.

### DIFF
--- a/django_sites_extensions/__init__.py
+++ b/django_sites_extensions/__init__.py
@@ -1,3 +1,2 @@
 """ django_sites_extensions main module """
-default_app_config = 'django_sites_extensions.apps.DjangoSitesExtensionsConfig'  # pragma: no cover
-__version__ = '4.0.0'
+__version__ = '4.0.1'


### PR DESCRIPTION
Django now detects this configuration automatically. You can remove
default_app_config.  This removes a warning from edx-platform startup
and deals with something that's going to be fully ignored in django
4.1

See https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery
for more details.
