### PR TITLE
build: Don't make wheel and setuptools base dependencies.

### DIFF
--- a/django_sites_extensions/__init__.py
+++ b/django_sites_extensions/__init__.py
@@ -1,2 +1,2 @@
 """ django_sites_extensions main module """
-__version__ = '4.1.0'
+__version__ = '4.2.0'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,5 +2,3 @@
 -c constraints.txt
 
 Django
-setuptools
-wheel

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,13 +14,7 @@ django==4.2.11
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via django
 typing-extensions==4.11.0
     # via asgiref
-wheel==0.43.0
-    # via -r requirements/base.in
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==69.2.0
-    # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -20,7 +20,7 @@ distlib==0.3.8
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -50,7 +50,7 @@ tomli==2.0.1
     #   tox
 tox==4.14.2
     # via -r requirements/tox.txt
-virtualenv==20.25.1
+virtualenv==20.25.3
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,7 +26,7 @@ docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.6
+idna==3.7
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -69,17 +69,11 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via django
 typing-extensions==4.11.0
     # via asgiref
 urllib3==2.2.1
     # via requests
-wheel==0.43.0
-    # via -r requirements/base.in
 zipp==3.18.1
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==69.2.0
-    # via -r requirements/base.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.43.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.2.0
+setuptools==69.5.1
     # via -r requirements/pip.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -12,3 +12,5 @@ pep8
 pytest-cov
 pytest-django
 twine
+setuptools
+wheel

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ astroid==3.1.0
     # via
     #   pylint
     #   pylint-celery
-backports-tarfile==1.0.0
+backports-tarfile==1.1.0
     # via jaraco-context
 backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
@@ -20,6 +20,8 @@ backports-zoneinfo==0.2.1 ; python_version < "3.9"
     #   django
 certifi==2024.2.2
     # via requests
+cffi==1.16.0
+    # via cryptography
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
@@ -35,6 +37,8 @@ coverage[toml]==7.4.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
+cryptography==42.0.5
+    # via secretstorage
 dill==0.3.8
     # via pylint
     # via
@@ -48,7 +52,7 @@ edx-lint==5.3.6
     # via -r requirements/test.in
 exceptiongroup==1.2.0
     # via pytest
-idna==3.6
+idna==3.7
     # via requests
 importlib-metadata==6.11.0
     # via
@@ -67,6 +71,10 @@ jaraco-context==5.3.0
     # via keyring
 jaraco-functools==4.0.0
     # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.3
     # via code-annotations
 keyring==25.1.0
@@ -99,6 +107,8 @@ platformdirs==4.2.0
     # via pylint
 pluggy==1.4.0
     # via pytest
+pycparser==2.22
+    # via cffi
 pygments==2.17.2
     # via
     #   readme-renderer
@@ -141,9 +151,11 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.1
     # via twine
+secretstorage==3.3.3
+    # via keyring
 six==1.16.0
     # via edx-lint
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -r requirements/base.txt
     #   django
@@ -172,12 +184,12 @@ urllib3==2.2.1
     #   requests
     #   twine
 wheel==0.43.0
-    # via -r requirements/base.txt
+    # via -r requirements/test.in
 zipp==3.18.1
     # via
     #   importlib-metadata
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==69.2.0
-    # via -r requirements/base.txt
+setuptools==69.5.1
+    # via -r requirements/test.in

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   tox
     #   virtualenv
@@ -34,5 +34,5 @@ tomli==2.0.1
     #   tox
 tox==4.14.2
     # via -r requirements/tox.in
-virtualenv==20.25.1
+virtualenv==20.25.3
     # via tox


### PR DESCRIPTION
We need them for testing and publishing but we don't need them to run
this library.
