### PR TITLE
Add support for django5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12']
-        toxenv: [quality, django42]
+        toxenv: [quality, django42, django52]
 
     steps:
     - name: checkout repo

--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,4 +1,4 @@
-[pep8]
+[pycodestyle]
 ignore=E501
 max_line_length=119
 exclude=settings,migrations,django_sites_extensions/static,bower_components

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,17 @@
+Change Log
+==========
+
+..
+   All enhancements and patches to django_sites_extensions will be documented
+   in this file.  It adheres to the structure of http://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+   This project adheres to Semantic Versioning (http://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.
+Unreleased
+----------
+
+5.1.0 - 2025-04-18
+---------------------
+* Added Support for ``django 5.2``.

--- a/django_sites_extensions/__init__.py
+++ b/django_sites_extensions/__init__.py
@@ -1,2 +1,2 @@
 """ django_sites_extensions main module """
-__version__ = '5.0.0'
+__version__ = '5.1.0'

--- a/pylintrc
+++ b/pylintrc
@@ -380,6 +380,6 @@ ext-import-graph =
 int-import-graph = 
 
 [EXCEPTIONS]
-overgeneral-exceptions = Exception
+overgeneral-exceptions = builtins.Exception
 
 # bb9e5d2b49545fb7c96745385e5e3f4966c0ea1a

--- a/requirements/django52.txt
+++ b/requirements/django52.txt
@@ -1,0 +1,2 @@
+asgiref==3.8.1
+django==5.2.0

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -8,7 +8,7 @@ coverage
 django-dynamic-fixture
 edx-lint
 mock
-pep8
+pycodestyle
 pytest-cov
 pytest-django
 twine

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -89,14 +89,14 @@ packaging==24.1
     # via pytest
 pbr==6.0.0
     # via stevedore
-pep8==1.7.1
-    # via -r requirements/test.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via pylint
 pluggy==1.5.0
     # via pytest
+pycodestyle==2.13.0
+    # via -r requirements/test.in
 pycparser==2.22
     # via cffi
 pygments==2.18.0
@@ -159,6 +159,7 @@ twine==5.1.1
     # via -r requirements/test.in
 urllib3==2.2.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   requests
     #   twine
 wheel==0.44.0
@@ -167,5 +168,4 @@ zipp==3.20.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==72.2.0
-    # via -r requirements/test.in
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -159,7 +159,6 @@ twine==5.1.1
     # via -r requirements/test.in
 urllib3==2.2.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   requests
     #   twine
 wheel==0.44.0
@@ -168,4 +167,5 @@ zipp==3.20.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools==72.2.0
+    # via -r requirements/test.in

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
     ],
     keywords='Django sites edx',
     url='https://github.com/openedx/edx-django-sites-extensions',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python{311,312}-django{42},quality,docs
+envlist = python{311,312}-django{42,52},quality,docs
 
 [testenv]
 setenv =
@@ -7,13 +7,14 @@ setenv =
     DJANGO_SETTINGS_MODULE = test_settings
 deps =
     django42: -r requirements/django42.txt
+    django52: -r requirements/django52.txt
     -r requirements/test.txt
 commands =
     pytest --cov=django_sites_extensions --cov-report=xml
 
 [testenv:quality]
 commands =
-    pep8 --config=.pep8 django_sites_extensions
+    pycodestyle --config=.pycodestyle django_sites_extensions
     pylint --rcfile pylintrc django_sites_extensions
     python setup.py bdist_wheel
     twine check dist/*


### PR DESCRIPTION
- Resolved https://github.com/openedx/edx-django-sites-extensions/issues/97

### Add Django 5.2 Support

This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

Changes Made:
- Update `ci` and `tox` files
- Ran `django-upgrade` to apply necessary syntax updates for Django 5.2.
- Run tests using `tox` command and resolved the warnings and outdated `pep8` usage
- Add `changelog`
- Ensured all modifications remain backward-compatible with Django 4.2.

#### django-upgrade usage:

I ran command `git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`