### PR TITLE
docs: Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,7 +14,6 @@ metadata:
       icon: "Article"
   annotations:
     openedx.org/arch-interest-groups: "angonz"
-    openedx.org/release: "master"
 spec:
   owner: user:angonz
   type: 'service'


### PR DESCRIPTION
This is a library and should not get tagged for named releases directly.  It is pulled into edx-platform which is currently tagged.